### PR TITLE
Adding the ability to specify color in the link

### DIFF
--- a/tools/leather-armor/scripts/index.js
+++ b/tools/leather-armor/scripts/index.js
@@ -234,7 +234,7 @@ function _allLoadingFinished() {
         draw();
     });
     
-    if (colorParam) {
+    if (colorParam && colorParam.match(/^[A-F0-9]{6}$/)) {
         updateColor(colorParam);
     } else {
         updateColor('FF0000');

--- a/tools/leather-armor/scripts/index.js
+++ b/tools/leather-armor/scripts/index.js
@@ -12,6 +12,13 @@ const bootsCanvas = document.getElementById('boots');
 
 const colorInput = document.getElementById('color');
 
+const params = new URL(document.location).searchParams;
+const colorParam = params.get('color');
+
+if (colorParam) {
+    colorInput.value = params.get(colorParam);
+}
+
 export const allCanvas = {
     h: helmCanvas,
     c: chestCanvas,

--- a/tools/leather-armor/scripts/index.js
+++ b/tools/leather-armor/scripts/index.js
@@ -233,13 +233,11 @@ function _allLoadingFinished() {
         state = 'active';
         draw();
     });
-    updateColor('FF0000');
     
-    console.log("Color Parameter: " + colorParam);
-    // There should probably be verification of the validity of the color parameter.
     if (colorParam) {
-        console.log("This has loaded");
         updateColor(colorParam);
+    } else {
+        updateColor('FF0000');
     }
 
     const selectedColorModel = Number(loadFromLocalStorage('cur-color-model'));

--- a/tools/leather-armor/scripts/index.js
+++ b/tools/leather-armor/scripts/index.js
@@ -15,10 +15,6 @@ const colorInput = document.getElementById('color');
 const params = new URL(document.location).searchParams;
 const colorParam = params.get('color');
 
-if (colorParam) {
-    colorInput.value = colorParam;
-}
-
 export const allCanvas = {
     h: helmCanvas,
     c: chestCanvas,
@@ -238,6 +234,11 @@ function _allLoadingFinished() {
         draw();
     });
     updateColor('FF0000');
+    
+    // There should probably be verification of the validity of the color parameter.
+    if (colorParam) {
+        updateColor(colorParam);
+    }
 
     const selectedColorModel = Number(loadFromLocalStorage('cur-color-model'));
 

--- a/tools/leather-armor/scripts/index.js
+++ b/tools/leather-armor/scripts/index.js
@@ -16,7 +16,7 @@ const params = new URL(document.location).searchParams;
 const colorParam = params.get('color');
 
 if (colorParam) {
-    colorInput.value = params.get(colorParam);
+    colorInput.value = colorParam;
 }
 
 export const allCanvas = {

--- a/tools/leather-armor/scripts/index.js
+++ b/tools/leather-armor/scripts/index.js
@@ -235,8 +235,10 @@ function _allLoadingFinished() {
     });
     updateColor('FF0000');
     
+    console.log("Color Parameter: " + colorParam);
     // There should probably be verification of the validity of the color parameter.
     if (colorParam) {
+        console.log("This has loaded");
         updateColor(colorParam);
     }
 


### PR DESCRIPTION
I added the ability to specify the color in the link with the "color" parameter, which only accepts 6 hexadecimal character inputs. If this input is missing or malformed, it returns to the default hex of "FF0000" like before this change. This could potentially be useful for making the process of uploading armor set files more automatic.